### PR TITLE
Update jupyterhub-singleuser

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ channels:
   - conda-forge
 
 dependencies:
-  - jupyterhub-singleuser>=3.0,<4.0
+  - jupyterhub-singleuser>=4.1.3
 
   # Everyone wants to use nbgitpuller for everything, so let's do that
   - nbgitpuller=1.1.*


### PR DESCRIPTION
The requirement for jupyterhub-singleuser would be good to update from >=3.0,<4.0 to for example >=4.1.3 --- on 2i2c hubs we have jupyterhub 4.0.2 on the server side, soon 4.1.3, and its okay to mismatch a bit but good to not fall behind too much.

If jupyterhub-singleuser is updated to version 5 here in this image and we use jupyterhub 4 on the server side, it should also be fine so I didn't add a `<5` specification here. 2i2c hubs will use modern versions of jupyterhub, so not pinning this helps you keep up to date.